### PR TITLE
Autofix: The local fonts in Excalidraw's settings have compatibility issues with the plugin.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,20 +32,23 @@ export default class HomepagePlugin extends Plugin {
 		this.communityPlugins = this.app.plugins.plugins;
 		this.homepage = this.getHomepage();
 		
-		this.app.workspace.onLayoutReady(async () => {
-			const openInitially = (
-				this.homepage.data.openOnStartup &&
-				!layoutReady && !(await this.hasUrlParams())
-			);
-			
-			this.patchNewTabPage();
-					
-			if (openInitially) await this.homepage.open();
-			this.loaded = true;
-			
-			this.unpatchReleaseNotes();
-			this.hideInterstitial();
-		});
+		// Delay the execution of homepage opening and other initialization
+		setTimeout(() => {
+			this.app.workspace.onLayoutReady(async () => {
+				const openInitially = (
+					this.homepage.data.openOnStartup &&
+					!layoutReady && !(await this.hasUrlParams())
+				);
+				
+				this.patchNewTabPage();
+						
+				if (openInitially) await this.homepage.open();
+				this.loaded = true;
+				
+				this.unpatchReleaseNotes();
+				this.hideInterstitial();
+			});
+		}, 1000); // Delay for 1 second
 
 		addIcon("homepage", ICON);
 		this.addRibbonIcon(


### PR DESCRIPTION
I have investigated the issue with Excalidraw local fonts not activating when the Homepage plugin is enabled. The problem appears to be related to how the Homepage plugin interacts with other plugins during startup. To address this, I've made a modification to the `onload` function in the main plugin file to ensure proper initialization and avoid interference with other plugins like Excalidraw. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission