### PR TITLE
ci: update release workflow to modern GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,15 @@ jobs:
       attestations: write
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "25.x"
+          node-version: "lts/*"
+          cache: "npm"
       - name: Build plugin
         run: |
-          npm install
+          npm ci
           npm run build
       - name: Generate attestation
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
## Summary

Updates the release GitHub Actions workflow to use modern action versions and best practices.

## Changes

- **actions/checkout**: v3 → v4  
  GitHub deprecated Node.js 16 runtime actions in April 2025. v3 actions stopped working after that date.

- **actions/setup-node**: v3 → v4  
  Same deprecation issue as above.

- **Build command**: 
up to date, audited 352 packages in 2s

148 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities → 
added 351 packages, and audited 352 packages in 3s

148 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities  
  
added 351 packages, and audited 352 packages in 5s

148 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities enforces  consistency, ensuring reproducible builds in CI environments.

- **Added npm cache**:  on setup-node  
  Speeds up dependency installation across workflow runs.

- **Node.js version**:  →   
  Uses the current LTS release for stability rather than a non-LTS version.

## Testing

- [x] 
added 351 packages, and audited 352 packages in 3s

148 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities works correctly
- [x] 
> obsidian-homepage@4.4.2 build
> node build.mjs production

ℹ  Typecheck started…
✔  Typecheck passed
ℹ  Typecheck finished in 852ms produces valid output

---
*This is an automated contribution from a learning exercise.*